### PR TITLE
Change to positioning.

### DIFF
--- a/web/styles/styles.css
+++ b/web/styles/styles.css
@@ -77,6 +77,7 @@
     box-shadow: 0 1px 1px rgba(0, 0, 0, 0.075) inset;
     color: #555555;
     padding: 5px 10px;
+    position: relative;
 }
 .form-item-container .list-inline {
     margin-bottom: 0;


### PR DESCRIPTION
With the positioning set to absolute there are adverse affects to the surrounding page, especially if used within a modal, due to stretching. As it's already inside a container (<div class="ng-ms form-item-container">)setting position:relative to it, allows it to stretch and float above while still conforming to the surrounding structure.